### PR TITLE
Fix recreation of recurring tasks when RECURRENCE-ID changes

### DIFF
--- a/app/src/main/java/at/techbee/jtx/SyncContentProvider.kt
+++ b/app/src/main/java/at/techbee/jtx/SyncContentProvider.kt
@@ -355,7 +355,10 @@ class SyncContentProvider : ContentProvider() {
                 createEmptyFileForAttachment(id)
 
             if (sUriMatcher.match(uri) == CODE_ICALOBJECTS_DIR
-                && (values?.containsKey(COLUMN_RRULE) == true || values?.containsKey(COLUMN_RDATE) == true || values?.containsKey(COLUMN_EXDATE) == true)
+                && (values?.containsKey(COLUMN_RRULE) == true ||
+                        values?.containsKey(COLUMN_RDATE) == true ||
+                        values?.containsKey(COLUMN_EXDATE) == true ||
+                        values?.containsKey(COLUMN_RECURID) == true)
             )
                 database.getRecurringToPopulate(id)?.let {
                     database.recreateRecurring(it)
@@ -656,10 +659,12 @@ class SyncContentProvider : ContentProvider() {
 
 
         // updates on recurring instances through bulk updates should not occur, only updates on single items will update the recurring instances
-        if (sUriMatcher.match(uri) == CODE_ICALOBJECT_ITEM && (values.containsKey(COLUMN_RRULE) || values.containsKey(
-                COLUMN_RDATE
-            ) || values.containsKey(COLUMN_EXDATE))
-        ) {
+        if (sUriMatcher.match(uri) == CODE_ICALOBJECT_ITEM &&
+            (values.containsKey(COLUMN_RRULE) ||
+                    values.containsKey(COLUMN_RDATE) ||
+                    values.containsKey(COLUMN_EXDATE) ||
+                    values.containsKey(COLUMN_RECURID))
+           ) {
             try {
                 val id: Long = uri.lastPathSegment?.toLong()
                     ?: throw NumberFormatException("Last path segment was null")


### PR DESCRIPTION
## Problem

When a recurring VTODO with an existing `RECURRENCE-ID` exception is imported through the sync content provider, jtx Board does not rebuild the generated recurrence instances.

As a result, the original occurrence generated from the `RRULE` remains in the database in addition to the modified exception.

Example:

A recurring task contains:

- Aug 20 – completed exception (`RECURRENCE-ID`)
- Aug 27 – open
- Sep 3 – open

After a fresh sync/import, jtx Board incorrectly displays:

- Aug 20 – open
- Aug 20 – completed
- Aug 27 – open
- Sep 3 – open

The open Aug 20 instance generated from the `RRULE` should be replaced by the exception.

## Cause

`SyncContentProvider` currently calls `recreateRecurring()` when `RRULE`, `RDATE` or `EXDATE` is inserted or updated.

However, changes involving `RECURRENCE-ID` don't trigger `recreateRecurring()`.

This means that when a recurrence exception is inserted after the recurring master, the already generated occurrence is not removed/rebuilt.

## Fix

Also trigger `recreateRecurring()` when `COLUMN_RECURID` is present, both for inserts and updates.

## Test

Tested with:

- jtx Board 2.17.00 OSE
- DAVx⁵ 4.5.19 OSE
- CalDAV server: Baïkal

Before the patch, a fresh synchronization produced 4 instances:

- Aug 20 – open
- Aug 20 – completed
- Aug 27 – open
- Sep 3 – open

After the patch and a fresh synchronization, the expected 3 instances are produced:

- Aug 20 – completed
- Aug 27 – open
- Sep 3 – open

The fix was successfully built and tested against jtx Board 2.17.00.

After rebasing the commit onto the current `develop` branch, a local build is currently blocked by an unrelated Android Gradle Plugin version conflict between jtx Board and the pinned `davx5-ose` composite build.